### PR TITLE
Pass additional metadata to cookiecutter context

### DIFF
--- a/cruft/_commands/create.py
+++ b/cruft/_commands/create.py
@@ -5,6 +5,7 @@ from cookiecutter.generate import generate_files
 
 from . import utils
 from .utils import example
+from .utils.clean import clean_context
 from .utils.iohelper import AltTemporaryDirectory
 
 
@@ -43,6 +44,8 @@ def create(
                 default_config,
                 extra_context,
                 no_input,
+                output_dir,
+                checkout,
             )
 
         project_dir = Path(
@@ -58,7 +61,7 @@ def create(
             "template": template_git_url,
             "commit": last_commit,
             "checkout": checkout,
-            "context": context,
+            "context": clean_context(context),
             "directory": directory,
         }
 

--- a/cruft/_commands/link.py
+++ b/cruft/_commands/link.py
@@ -5,6 +5,7 @@ import typer
 
 from . import utils
 from .utils import example
+from .utils.clean import clean_context
 from .utils.iohelper import AltTemporaryDirectory
 
 
@@ -39,6 +40,8 @@ def link(
             default_config,
             extra_context,
             no_input,
+            project_dir,
+            checkout,
         )
         if no_input:
             use_commit = last_commit
@@ -56,7 +59,7 @@ def link(
                     "template": template_git_url,
                     "commit": use_commit,
                     "checkout": checkout,
-                    "context": context,
+                    "context": clean_context(context),
                     "directory": directory,
                 }
             )

--- a/cruft/_commands/utils/clean.py
+++ b/cruft/_commands/utils/clean.py
@@ -1,0 +1,9 @@
+def clean_context(context):
+    cleaned_context = context
+    keys_to_remove = ["_output_dir", "_repo_dir"]
+
+    for key in keys_to_remove:
+        if key in cleaned_context["cookiecutter"]:
+            del cleaned_context["cookiecutter"][key]
+
+    return cleaned_context

--- a/cruft/_commands/utils/cookiecutter.py
+++ b/cruft/_commands/utils/cookiecutter.py
@@ -1,4 +1,5 @@
 import json
+import os
 from pathlib import Path
 from typing import Any, Dict, Optional
 from urllib.parse import urlparse
@@ -80,6 +81,8 @@ def generate_cookiecutter_context(
     default_config: bool = False,
     extra_context: Optional[Dict[str, Any]] = None,
     no_input: bool = False,
+    project_dir: Path = Path("."),
+    checkout: Optional[str] = None,
 ) -> CookiecutterContext:
     _validate_cookiecutter(cookiecutter_template_dir)
 
@@ -98,6 +101,16 @@ def generate_cookiecutter_context(
     # except when 'no-input' flag is set
     context["cookiecutter"] = prompt_for_config(context, no_input)
     context["cookiecutter"]["_template"] = template_git_url
+
+    # include output dir in the context dict
+    context["cookiecutter"]["_output_dir"] = os.path.abspath(project_dir)
+
+    # include repo dir in the context dict
+    context["cookiecutter"]["_repo_dir"] = os.path.abspath(cookiecutter_template_dir)
+
+    # include checkout details in the context dict
+    if checkout is not None:
+        context["cookiecutter"]["_checkout"] = checkout
 
     return context
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,6 +160,8 @@ def test_link(cruft_runner, cookiecutter_dir):
     # compare the 2 .cruft.json
     cruft_file = utils.cruft.get_cruft_file(cookiecutter_dir)
     cruft_config_from_link = json.loads(cruft_file.read_text())
+    assert "_output_dir" not in cruft_config_from_create
+    assert "_repo_dir" not in cruft_config_from_create
     assert cruft_config_from_create == cruft_config_from_link
 
 


### PR DESCRIPTION
This change adds several metadata fields to the context, before it's passed to Cookiecutter. This enables the use of the fields by cookiecutter (e.g. to determine the temporary directory when running pre/post generation hooks). These fields are automatically set when using the cookiecutter CLI, but not by cruft itself, because of the variance in codepaths between the two tools.

The use case differs from `extra_context` as the fields added are universal metadata, rather than specific to a given project. 

To ensure a clean output in `.cruft.json` (i.e. - removing temporary directory information), we remove the fields from the context before writing to the cruft file.