### PR TITLE
Set project overwrite as default

### DIFF
--- a/cruft/_cli.py
+++ b/cruft/_cli.py
@@ -100,13 +100,6 @@ def create(
         "-c",
         help=("The git reference to check against. Supports branches, tags and commit hashes."),
     ),
-    overwrite_if_exists: bool = typer.Option(
-        False,
-        "--overwrite-if-exists",
-        "-f",
-        show_default=False,
-        help="Overwrite the contents of the output directory if it already exists",
-    ),
     skip: Optional[List[str]] = typer.Option(
         None, "--skip", show_default=False, help="Default files/pattern to skip on update"
     ),
@@ -121,7 +114,6 @@ def create(
         no_input=no_input,
         directory=directory,
         checkout=checkout,
-        overwrite_if_exists=overwrite_if_exists,
         skip=skip,
     )
 

--- a/cruft/_commands/create.py
+++ b/cruft/_commands/create.py
@@ -20,7 +20,6 @@ def create(
     no_input: bool = True,
     directory: Optional[str] = None,
     checkout: Optional[str] = None,
-    overwrite_if_exists: bool = False,
     skip: Optional[List[str]] = None,
 ) -> Path:
     """Expand a Git based Cookiecutter template into a new project on disk."""
@@ -52,7 +51,7 @@ def create(
             generate_files(
                 repo_dir=cookiecutter_template_dir,
                 context=context,
-                overwrite_if_exists=overwrite_if_exists,
+                overwrite_if_exists=True,
                 output_dir=str(output_dir),
             )
         )


### PR DESCRIPTION
Overwrite files in the output directory by default.

Required to enable project templating when using pre-generation hooks.